### PR TITLE
chore: make this component available as Hugo module

### DIFF
--- a/README.org
+++ b/README.org
@@ -17,6 +17,6 @@ This is not a standalone theme. This is a Hugo theme component or module.
    #+begin_example
    [module]
    [[module.imports]]
-   path = "module github.com/kaushalmodi/hugo-debugprint"
+   path = "github.com/kaushalmodi/hugo-debugprint"
    disabled = false
    #+end_example

--- a/README.org
+++ b/README.org
@@ -1,10 +1,22 @@
-This is not a standalone theme. This is a Hugo theme component.
+This is not a standalone theme. This is a Hugo theme component or module.
 
-To use this:
+## Usage
+
+### Install as repository below ~themes~
 
 1. Clone this repo to ~your-site/themes/hugo-debugprint~ directory.
 2. Add "hugo-debugprint" as the left-most element of the ~theme~ list variable
    in your site's or theme's ~config.toml~. Example:
    #+begin_example
    theme = ["hugo-debugprint", "my-theme"]
+   #+end_example
+
+### Install as Hugo module
+
+1. Add the following code to your ~config.toml~
+   #+begin_example
+   [module]
+   [[module.imports]]
+   path = "module github.com/kaushalmodi/hugo-debugprint"
+   disabled = false
    #+end_example

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kaushalmodi/hugo-debugprint
+
+go 1.15


### PR DESCRIPTION
This PR makes your component available as Hugo module. If you choose to merge this PR please create a version "v1.0.0" or any number (the v in the beginning though seems to be required) here on Github to make it easier for Hugo to decide what commits to download.

If you choose to not make your component available as module please just close this issue ;)

I could not test it thoroughly due to the nature of modules, but will do and fix potential issues if you merge.